### PR TITLE
use a simple entrypoint instead of systemd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,6 @@ COPY files/motd.md /etc/motd.md
 COPY files/apache/00-mutex.conf /etc/httpd/conf.d/00-mutex.conf
 RUN mkdir -p /run/httpd
 
-CMD [ "/sbin/init" ]
+COPY files/entrypoint.sh /bin/entrypoint.sh
+
+CMD [ "/bin/entrypoint.sh" ]

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/opt/ood/ood-portal-generator/sbin/update_ood_portal --rpm -f --insecure
+
+sudo -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml 2>&1 &
+
+/usr/sbin/httpd -DFOREGROUND
+
+echo 'made it here'

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -4,6 +4,5 @@
 
 sudo -u ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml 2>&1 &
 
+/usr/libexec/httpd-ssl-gencerts
 /usr/sbin/httpd -DFOREGROUND
-
-echo 'made it here'


### PR DESCRIPTION
use a simple entrypoint instead of systemd to help with systems like MacOS where systemd can cause issues.