### PR TITLE
Fix docker run path: systemd requires `--privileged`; add boot test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build_image:
-    name: Build the image
+    name: Build the image (rake / podman path)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,3 +24,59 @@ jobs:
           bundler-cache: true
       - name: build image
         run: rake build
+
+  build_arm64:
+    name: Build the image (arm64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: build image
+        run: docker build -t ood-demo-test:arm64 -f Dockerfile .
+
+  boot_test:
+    name: Boot test (docker path)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build image with docker
+        run: docker build -t ood-demo-test:latest -f Dockerfile .
+
+      - name: Start container as documented in the README
+        run: |
+          docker run --rm --detach --name ood_demo --privileged \
+            -p 8080:8080 -h ood.demo ood-demo-test:latest
+
+      - name: Wait for the portal to answer on 8080
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:8080; then
+              echo "Portal is up after ~$((i * 5)) seconds"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Portal never came up on port 8080" >&2
+          exit 1
+
+      - name: Verify login page is reachable through the auth redirect
+        run: |
+          # Following redirects from / should land on the Dex login page.
+          page=$(curl -sL http://localhost:8080)
+          echo "$page" | grep -qi 'login' || {
+            echo "Did not find a login page after following redirects" >&2
+            exit 1
+          }
+
+      - name: Show service status on failure
+        if: failure()
+        run: |
+          docker exec ood_demo systemctl --failed || true
+          docker exec ood_demo journalctl -u httpd -u ondemand-dex --no-pager | tail -100 || true
+          docker logs ood_demo || true
+
+      - name: Stop container
+        if: always()
+        run: docker stop ood_demo || true

--- a/README.md
+++ b/README.md
@@ -6,27 +6,34 @@ A container for demonstrating OpenOnDemand
 Pull this repository down and issue `rake build` to build the container.
 Or pull it from dockerhub at `openondemand/open-ondemand-demo:latest`.
 
+The published image is multi-arch (`linux/amd64` and `linux/arm64`), so it runs
+natively on both Intel/AMD machines and Apple Silicon Macs.
+
 ## Starting the container
 
-If you'd like to build and start the container, the rake task `rake start`.
+If you'd like to build and start the container, use the rake task `rake start`.
 
 If you'd like to pull the image off of dockerhub, pull the image and start it with
 these commands.
 
 Note that it's important to start on port `8080` as that's what the container expects.
-It relies on `localhost` so running through over the network will require additional work.
+It relies on `localhost` so running it over the network will require additional work.
 
 In addition, starting it with the hostname `ood.demo` (`-h ood.demo`) is important
 for proxying and shell access as both rely on allowlists which have been preconfigured.
 
+The `--privileged` flag is required because the container boots systemd as PID 1.
+Without it, Docker starts the container but no services (and no web portal) ever
+come up.
+
 ```
 docker pull openondemand/open-ondemand-demo:latest
-docker run --rm -p 8080:8080 -h ood.demo openondemand/open-ondemand-demo:latest
+docker run --rm --privileged -p 8080:8080 -h ood.demo openondemand/open-ondemand-demo:latest
 ```
-or 
+or
 ```
 podman pull docker.io/openondemand/open-ondemand-demo:latest
-podman run --rm -p 8080:8080 -h ood.demo --privileged docker.io/openondemand/open-ondemand-demo:latest
+podman run --rm --privileged -p 8080:8080 -h ood.demo docker.io/openondemand/open-ondemand-demo:latest
 ```
 
 ## Logging in
@@ -34,3 +41,41 @@ podman run --rm -p 8080:8080 -h ood.demo --privileged docker.io/openondemand/ope
 Once the container is started, it will be accessible at `http://localhost:8080`.
 
 A user has already been created, simply login as `jesse@localhost` with the password `owens`.
+
+## Troubleshooting
+
+**The terminal shows nothing after `docker run`.** This is expected. The container
+boots systemd, which logs to its own journal rather than the container's stdout,
+so a foreground run appears silent even when everything is working. Give it
+about 30 seconds after starting before opening the browser. Do not press
+`Ctrl-C` — systemd treats that as a shutdown signal and, combined with `--rm`,
+the container will stop and be removed.
+
+**"Unable to connect" in the browser right after starting.** The first boot has
+to generate the portal and Dex configuration before Apache starts listening.
+Wait roughly 30 seconds and reload.
+
+**"Bad Request" after logging in.** Your browser is holding OIDC cookies from a
+previous run of the container that no longer validate. Clear cookies for
+`localhost` (or use a private/incognito window) and log in again. This is most
+common with images built before the fixed `oidc_crypto_passphrase` was added
+(#31), where every container start regenerated the OIDC secrets.
+
+**Port 8080 is already in use.** Another application (commonly a Jupyter server
+or a development web server) is already bound to 8080. Stop it and start the
+container again. The container must be published on host port 8080 — the portal
+is configured for `localhost:8080` and other host ports will not work without
+additional configuration.
+
+**Shell or interactive apps fail but the dashboard works.** You most likely
+started the container without `-h ood.demo`. The shell and proxy allowlists are
+preconfigured for that hostname, so it is required.
+
+To check on the services inside a running container:
+
+```
+docker exec <container-name> systemctl --failed
+docker exec <container-name> journalctl -u httpd -u ondemand-dex --no-pager
+```
+
+(Substitute `podman` for `docker` as appropriate.)

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -29,9 +29,12 @@ def container_runtime
 end
 
 def demo_run_cmd
+  # --privileged is required because the container boots systemd as PID 1.
+  # Podman's systemd mode can often manage without it, but Docker cannot,
+  # and the flag is harmless where it isn't strictly needed.
   [ container_runtime, 'run', '--rm', '--detach',
-    '--name', 'ood_demo', '-p 8080:8080',
-    '-h', 'ood.demo',
+    '--name', 'ood_demo', '--privileged',
+    '-p 8080:8080', '-h', 'ood.demo',
     "#{image_name}:#{tag}"
   ].join(' ')
 end


### PR DESCRIPTION
Follows on from #29 and #31. The README's `docker` command and `rake start` both omit `--privileged`, which the `podman` command already has. Since the container boots systemd as PID 1, Docker without that flag starts the container but never brings up httpd or dex — the container looks alive while nothing listens on `8080`.

Reproduced on Ubuntu with Docker: the documented command yields no listener and a connection-refused in the browser. Adding `--privileged` fixes it; confirmed end to end (login as jesse@localhost, dashboard, shell).

Changes:

README: add `--privileged` to the `docker` command and explain why it's needed
README: troubleshooting section for the failure modes I hit while testing — silent `stdout` during `systemd` boot (people Ctrl-C thinking it's hung, which shuts it down), slow first boot, stale OIDC cookies on pre-#31 images, port 8080 conflicts, missing `-h ood.demo`
lib/utils.rb: add `--privileged` to demo_run_cmd so `rake start` works on Docker (harmless on podman)
CI: new `boot_test` job that runs the container exactly as the `README` documents, waits for `8080`, and verifies the auth redirect reaches the Dex login page. Dumps `systemctl --failed` and the httpd/dex journals on failure. This is the gap that let the broken docker command ship — we built the image in CI but never booted it.

With the tutorial coming up, wanted the documented quick-start path to work on both Docker and podman without tribal knowledge.