### PR TITLE
Fix container config and refresh the tutorial for OnDemand 4.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,18 +5,69 @@ on:
     tags:
       - '*'
 
+defaults:
+  run:
+    shell: bash
+
+# Two releases tagged close together would otherwise race to write the same
+# manifest.
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
-  push_to_registry:
-    name: Push Docker image to Repositories
-    runs-on: ubuntu-latest
+  # Build each architecture on its own native runner rather than cross-building
+  # under QEMU, which is considerably slower for an image this size.
+  build:
+    name: Build ${{ matrix.arch }} image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      - name: build images
-        run: | 
-          rake build
+        with:
+          fetch-depth: 0
+
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: build image
+        run: rake build
+
       - name: login to dockerhub
-        run: podman login docker.io -u ${{ secrets.OOD_DOCKERHUB_USER }} -p ${{ secrets.OOD_DOCKERHUB_TOKEN }}
-      - name: push images to dockerhub
-        run: |
-          rake publish['docker.io']
+        run: echo "${{ secrets.OOD_DOCKERHUB_TOKEN }}" | podman login docker.io -u ${{ secrets.OOD_DOCKERHUB_USER }} --password-stdin
+
+      - name: push per-arch image
+        run: rake publish_arch['docker.io','${{ matrix.arch }}']
+
+  # Merge the per-arch images into a manifest list so that
+  # `docker pull openondemand/open-ondemand-demo` resolves to the right
+  # architecture automatically.
+  manifest:
+    name: Push multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: login to dockerhub
+        run: echo "${{ secrets.OOD_DOCKERHUB_TOKEN }}" | podman login docker.io -u ${{ secrets.OOD_DOCKERHUB_USER }} --password-stdin
+
+      - name: create and push manifest
+        run: rake manifest['docker.io']

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ COPY files/clusters.d /etc/ood/config/clusters.d
 COPY files/apps /var/www/ood/apps/sys/
 COPY files/config /etc/ood/config/apps/
 COPY files/motd.md /etc/motd.md
+COPY files/nginx_stage.yml /etc/ood/config/nginx_stage.yml
+COPY files/ondemand.d /etc/ood/config/ondemand.d
 
 COPY files/apache/00-mutex.conf /etc/httpd/conf.d/00-mutex.conf
 RUN mkdir -p /run/httpd

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,14 @@ RUN dnf -y update && \
     dnf groupinstall -y "xfce" && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
-# RUN pip3 install 'setuptools_scm<7' && \
-RUN pip3 install jupyter
+# Pinned because Rocky 9 ships Python 3.9 and newer releases of this stack
+# require 3.10+, so an unpinned install silently stops working over time.
+RUN pip3 install \
+      jupyter==1.1.1 \
+      jupyterlab==4.5.10 \
+      notebook==7.5.7 \
+      nbformat==5.10.4 \
+      fastjsonschema==2.21.2
 
 RUN sed -i 's|--rpm|--rpm -f --insecure|g' /etc/systemd/system/httpd.service.d/ood-portal.conf
 RUN systemctl enable httpd ondemand-dex

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,13 @@ RUN chmod 600 /etc/shadow
 USER jesse
 RUN mkdir -p /home/jesse/ondemand/dev
 
+# Set up the Job Composer's database so the app is usable on first load.
+# SECRET_KEY_BASE is only needed to boot Rails here; the PUN supplies its own at
+# runtime. The checkpoint folds the schema out of the write-ahead log so the
+# database file is self-contained in the image.
+# Exec form so the shell is bash — `source` isn't available in Docker's default sh.
+RUN ["/bin/bash", "-lc", "source /opt/ood/ondemand/enable && cd /var/www/ood/apps/sys/myjobs && SECRET_KEY_BASE=$(openssl rand -hex 32) RAILS_ENV=production bin/rake db:setup && python3 -c \"import sqlite3; sqlite3.connect('/home/jesse/ondemand/data/sys/myjobs/production.sqlite3').execute('PRAGMA wal_checkpoint(TRUNCATE)')\""]
+
 # switch back to root to do everything else
 USER root
 RUN git clone https://github.com/OSC/bc_example_jupyter.git --bare /var/git/bc_example_jupyter

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN dnf install -y https://yum.osc.edu/ondemand/4.2/ondemand-release-web-4.2-1.e
     dnf install -y https://yum.osc.edu/ondemand/4.2/ondemand-release-compute-4.2-1.el9.noarch.rpm && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
+# python3-devel resolves against a newer python3 than the first update leaves
+# in place, so python3 is brought up to match before installing it.
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled crb && \
     dnf -y module enable nodejs:22 ruby:3.3 && \
     dnf install -y epel-release && \
+    dnf -y update python3 python3-libs && \
     dnf install -y procps libffi-devel python3-devel gcc && \
     dnf install -y ondemand ondemand-dex && \
     dnf install -y xz libyaml-devel turbovnc python3-websockify && \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ Or pull it from dockerhub at `openondemand/open-ondemand-demo:latest`.
 The published image is multi-arch (`linux/amd64` and `linux/arm64`), so it runs
 natively on both Intel/AMD machines and Apple Silicon Macs.
 
+## Building from source
+
+`rake build` uses buildah or podman where they're installed, and docker
+otherwise. To build with docker directly:
+
+```
+git clone https://github.com/OSC/ood-demo.git
+cd ood-demo
+docker build -t ood-demo -f Dockerfile .
+```
+
+Then start it as described below, substituting `ood-demo` for the dockerhub
+image name.
+
+The build pulls a few GB and takes a while - it's a full Rocky 9 with XFCE,
+TurboVNC and Jupyter. The finished image is around 2.7GB on disk.
+
+On Apple Silicon, add `--platform linux/arm64` to build natively. Running an
+amd64 image under emulation is slow and has been seen to crash Docker Desktop.
+
 ## Starting the container
 
 If you'd like to build and start the container, use the rake task `rake start`.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -13,7 +13,7 @@ Live tutorial steps we took during PEARC. See the PEARC video recording to follo
 - [Passenger App Tutorial](#passenger-app-tutorial)
 - [XDMoD Integration Tutorial](#xdmod-integration-tutorial)
 
-These tutorial will be using the `dockerfile.demo` provided in the fronted Open OnDemand repo.
+This tutorial uses the container built from the `Dockerfile` in this repo.
 
 ## External links
 
@@ -72,8 +72,10 @@ you'll see buttons here to relaunch those applications.
 The 'Message of the Day' can display your message of the day similar to how shell
 logins work. OnDemand supports many formats, and the one shown is in markdown.
 
-Lastly you'll see panels for [XDMoD](../xdmod/README.md). OnDemand integrates
-with XDMoD to show pertinant information about the jobs you've recently ran.
+OnDemand can also integrate with [XDMoD](https://open.xdmod.org/) to show
+pertinent information about the jobs you've recently run. Those panels aren't
+enabled here by default - see the [XDMoD Integration
+Tutorial](#xdmod-integration-tutorial) below.
 
 ![landing page demo](imgs/landing_page_demo.gif)
 
@@ -194,7 +196,7 @@ Interactive apps are one of the main features of Open OnDemand. They allow
 users a click through interface to some of the most popular applications in
 HPC.
 
-This tutorial will go over luanching the Jupyter application as well as generic
+This tutorial will go over launching the Jupyter application as well as generic
 Linux desktops
 
 The `Interactive Apps` dropdown menu on the top navigation bar lists all the
@@ -211,8 +213,7 @@ a real site may allow desktops with GPUs and a checkbox in the form for the user
 select a GPU.
 
 There's no need to specify the account, so you can leave it blank. Fill out the rest
-of the form (noting that there are only 2 nodes in this cluster) and press the `Launch`
-button.
+of the form and press the `Launch` button.
 
 You'll be redirected to `My Interactive Sessions` page where you will see a card for this
 job. It should start in the queued state and eventually into the running state. When
@@ -220,8 +221,8 @@ it's in the running state a button will appear at the bottom of the card with th
 `Launch HPC Desktop`. Press that button when it becomes available to connect to the desktop.
 
 When you press `Launch HPC Desktop` a new tab will open connecting you to the desktop.
-Note that this desktop is running in a container on one of the compute nodes in the Slurm
-cluster.  You now have a desktop running on your compute cluster!
+This demo container runs jobs locally, but on a real site this desktop would be running
+on one of your compute nodes.  You now have a desktop running through OnDemand!
 
 Open the applications menu and launch a terminal. Once inside the terminal issue the
 `glxgears` command and see the GUI for glxgears open up.  Feel free to keep the session
@@ -248,16 +249,16 @@ users make in the form in these cards.
 
 Again when the button to `Connect to Jupyter` becomes available don't press it
 just yet. Instead you can press the button near the top of the card labeled `Host`.
-This is the host that the job is running on. It's likely cpn01 but could also be
-cpn02.  Press this button and OnDemand will open a shell session on that compute
-node in a new tab.
+This is the host that the job is running on - here that's the demo container itself,
+but on a real site it would be a compute node.  Press this button and OnDemand will
+open a shell session on that host in a new tab.
 
 This allows users to not only run an interactive application they can connect to,
 but also shell access to the job as well.
 
 Navigate back to Open OnDemand's `My interactive sessions` page and press the
 `Connect to Jupyter` button. This will open a new tab to the Jupyter application
-that's running on a compute node in your Slurm cluster!
+that's running on your job's host!
 
 Connect to the Jupyter session and navigate to the `jupyter_notebook_data` directory.
 Open the `GUI-demo.ipynb` and this should open a new tab to this notebook. Run all
@@ -320,10 +321,7 @@ This tutorial covers:
 First we need to pull the source code from the Github Repository. Let's
 [use the shell app](http://localhost:8080/pun/sys/shell/ssh/ood.demo) for this.
 
-Be sure to be on the `ondemand` host because that container has node and ruby on it,
-which we need to build the project.
-
-If you are not using the shell app, use `ssh` to connect to the `ondemand` host from the `frontend` host: `ssh ondemand`
+The demo container has node and ruby on it, which we need to build the project.
 
 Then, do the following:
 
@@ -333,7 +331,7 @@ mkdir -p ~/ondemand/dev
 cd ~/ondemand/dev
 ln -s ../../ondemand-src-full/apps/dashboard/ dashboard
 cd dashboard
-git checkout release_3.0
+git checkout release_4.2
 bin/bundle config --local path vendor/bundle
 bin/setup
 ```
@@ -435,7 +433,7 @@ Let's add these two environment variables to our `~/ondemand/dev/dashboard/.env.
 ```text
 # /home/jesse/ondemand/dev/dashboard/.env.local
 
-MOTD_PATH=/etc/motd
+MOTD_PATH=/etc/motd.md
 MOTD_FORMAT=markdown
 ```
 
@@ -491,7 +489,7 @@ any text you like here. Feel free to have fun with it!
 ```html
 <!-- /home/jesse/ondemand/config/views/widgets/_hello_world.html -->
 <div class='alert alert-info text-center' style='font-size:2.2rem;'>
-    <p>Thank you for attending the PEARC 2022 Open OnDemand Tutorial!</p>
+    <p>Thank you for attending the PEARC 2026 Open OnDemand Tutorial!</p>
 </div>
 ```
 
@@ -542,20 +540,26 @@ your app easier to reason about and faster to develop on.
 my_app/
 ├── form.yml.erb      ← User-facing form
 ├── manifest.yml      ← App metadata (Used for dashboard data)
-├── connection.yml    ← App server data needed on frontend (logins, hostnames, etc.)
 ├── submit.yml.erb    ← Job submission params
 └── template/
     ├── before.sh.erb  ← Pre-launch setup
     ├── script.sh.erb  ← Main launch script
-    └── after.sh.erb   ← Cleanup (Run at the end of the session)
+    ├── after.sh.erb   ← Runs right after the app is launched
+    └── clean.sh.erb   ← Cleanup (runs when the job ends)
 ```
 
 **Interactive App File Execution Flow:**
 1. `form.yml.erb` — Renders form → user fills it out, admin prepopulates, or content is fetched from cache 
 2. `submit.yml.erb` — Generates job submission config
 3. `before.sh.erb` — Runs before main script
-4. `script.sh.erb` — Launches the application
-5. `after.sh.erb` — Cleanup runs when the _session_ ends (_Not_ when the job ends)
+4. `script.sh.erb` — Launches the application in the background
+5. `after.sh.erb` — Runs immediately after the launch, while the app is starting.
+   This is where you wait for the app to be ready - the shipped Jupyter app uses
+   it to block until the server opens its port.
+6. OnDemand writes `connection.yml` (host, port, password) into the session
+   directory. You don't author this file - it's generated for you, and it's what
+   the "Connect to" button uses.
+7. `clean.sh.erb` — Cleanup, when the job ends
 
 - Docs: https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive.html
 - Helpers source: https://github.com/OSC/ondemand/tree/master/apps/dashboard/app/helpers
@@ -624,14 +628,17 @@ The `session` object provides runtime information about the current batch connec
 | Attribute              | What it gives you                              |
 |------------------------|------------------------------------------------|
 | `session.id`           | Unique session identifier                      |
-| `session.job_id`       | The scheduler job ID                           |
-| `session.cluster`      | Name of the cluster (matches cluster configs)  |
+| `session.job_id`       | The scheduler job ID (not set yet in `template/` scripts - the job hasn't been submitted) |
+| `session.cluster_id`   | Name of the cluster (matches cluster configs)  |
 | `session.staged_root`  | Path to the session's staged directory          |
 | `session.created_at`   | When the session was created                   |
 
+To branch on the cluster, use `context.cluster` - it's the string from the
+form. (`session.cluster` is the cluster *object*, not its name.)
+
 ```bash
 # Example: Kubernetes-aware logic
-<%- if session.cluster =~ /kubernetes/ -%>
+<%- if context.cluster =~ /kubernetes/ -%>
   # K8s-specific setup here
 <%- end -%>
 ```
@@ -643,6 +650,8 @@ Open OnDemand provides helper methods that we see users reinvent all the time. *
 #### `find_port`
 
 Finds an available port on the compute node. No need to hardcode or guess.
+Takes an optional host, then an optional port range (defaults: `localhost`,
+2000-65535).
 ```bash
 # In script.sh.erb:
 port=$(find_port ${host})
@@ -662,14 +671,15 @@ export RSTUDIO_PASSWORD="${password}"
 
 #### `connection.yml` entry
 
-Suppose we have an app that wants to use its own auth mechanism.  would 
-not be aware of this password which gets generated and it could create a 
+Suppose we have an app that wants to use its own auth mechanism. Open OnDemand
+would not be aware of this password which gets generated and it could create a
 complex work around in order to retrieve this data to share with Open OnDemand.
 
-Well Open OnDemand has a pattern for this! We use the `connection.yml` and the 
-`conn_params` in the `submit.yml.erb` file in conjunction with the app's 
-`view.html.erb` file to generate this data, plug it in for the user, and never 
-expose the credentials or involve sharing of those credentials.
+Well Open OnDemand has a pattern for this! Set `conn_params` in the
+`submit.yml.erb` and OnDemand writes those values into a `connection.yml` for
+the session, which the app's `view.html.erb` can then read. That plugs the
+credentials in for the user without ever exposing them. Note `host`, `port` and
+`password` are always included, so you only list the extras you need.
 
 We will use RStudio to show this pattern off, and to notice that this app 
 needs a `csrf` token to launch, another quirk you may find in apps that 
@@ -711,7 +721,7 @@ put all this data into our app's session card when it's ready:
   let expires = "expires=" + date.toUTCString();
   let cookiePath = "path=/rnode/" + "<%= host.to_s %>" + "/" + "<%= port.to_s %>/";
   /**
-    rstuido wants a cookie called csrf-token - but that's going to change in 2020!
+    rstudio wants a cookie called csrf-token - but that's going to change in 2020!
   */
   let cookie = `csrf-token=<%= csrf_token %>;${expires};${cookiePath};SameSite=strict;secure`;
   document.cookie = cookie;
@@ -879,6 +889,12 @@ In the file Editor, specify `localhost` as the cluster attribute near the top of
 so: `cluster: "localhost"`. This matches the cluster configured in this container at
 `/etc/ood/config/clusters.d/localhost.yml`. Save this file by clicking the "Save" button at
 the top left.
+
+> **Changes to a sandbox app need a web server restart.** The dashboard caches
+> your sandbox apps, so after editing `form.yml`, `submit.yml.erb` or
+> `manifest.yml` you'll need to restart before the change shows up. Use
+> "Restart Web Server" in the `</>` Develop menu. If you edit a file and the
+> form looks the same - or you get the same error again - this is usually why.
 
 #### Launch the Jupyter Application
 
@@ -1259,7 +1275,7 @@ At this point, this should be the entirety of the `submit.yml.erb` and `form.yml
 They're given here in full if you want to copy/paste them. And remember to [save your spot](#save-your-spot)!
 
 ```yaml
-# script.yml.erb
+# submit.yml.erb
 ---
 script:
   queue_name: "<%= custom_queue %>"
@@ -1324,7 +1340,7 @@ Refresh the [new session form](http://localhost:8080/pun/sys/dashboard/batch_con
 and you should now see your updates.
 
 For this change, there's no need to edit the `submit.yml.erb`.  This toggle happens in the
-actual script that's ran during the job, so we have to edit `template.sh.erb`.  Note that
+actual script that's ran during the job, so we have to edit `template/script.sh.erb`.  Note that
 this is also an ERB script, so it gets templated in Ruby before being submitted to the
 scheduler.
 
@@ -2003,6 +2019,4 @@ Review Job Composer links - access Job Composer
 </details>
 
 ## Tutorial Navigation
-[Next Step - Open XDMoD](../xdmod/README.md)  
-[Previous Step - ColdFront](../coldfront/README.md)  
-[Back to Start](../README.md)  
+[Back to Start](README.md)  

--- a/files/nginx_stage.yml
+++ b/files/nginx_stage.yml
@@ -1,0 +1,9 @@
+---
+# Enables the dashboard's "Develop" menu, which the app development tutorial
+# depends on. Without OOD_DEV_APPS_ROOT set it defaults to /dev/null and the
+# menu never appears.
+#
+# %{user} is not interpolated here — nginx_stage only substitutes it in path
+# settings, not in pun_custom_env values. This container has a single user.
+pun_custom_env:
+  OOD_DEV_APPS_ROOT: "/var/www/ood/apps/dev/jesse/gateway"

--- a/files/ondemand.d/dynamic.yml
+++ b/files/ondemand.d/dynamic.yml
@@ -1,0 +1,6 @@
+---
+# Enable dynamic batch connect form fields (data-min-*, data-max-*, data-set-*,
+# data-hide-*). This defaults to false in OnDemand 4.2, and without it the
+# tutorial's "Dynamic Batch Connect Fields" sections silently do nothing — the
+# data attributes render into the option tags but no JavaScript consumes them.
+bc_dynamic_js: true

--- a/lib/demo.rb
+++ b/lib/demo.rb
@@ -32,3 +32,54 @@ task :publish, [:repo] => [:build] do |t, args|
   sh "#{container_runtime} push #{repo}/#{image_name}:#{tag}"
   sh "#{container_runtime} push #{repo}/#{image_name}:latest"
 end
+
+desc 'Publish a single-architecture image, tagged with its arch suffix'
+# No :build dependency - the workflow builds in its own step, and rebuilding
+# here would be a second `git clone` of the example app that could differ.
+task :publish_arch, [:repo, :arch] do |t, args|
+  repo = args[:repo]
+  arch = args[:arch]
+  raise(StandardError, "Repository is not specified. Example: \"rake publish_arch['docker.io','amd64']\"") if repo.nil?
+  raise(StandardError, "Architecture is not specified. Example: \"rake publish_arch['docker.io','amd64']\"") if arch.nil?
+
+  # Only the versioned per-arch tag. These are scratch tags for the manifest
+  # job to assemble; pushing a shared `latest-<arch>` would let concurrent
+  # releases mix architectures from different builds.
+  dest = "#{repo}/#{image_name}:#{tag}-#{arch}"
+  sh "#{container_runtime} tag #{image_name}:#{tag} #{dest}"
+  sh "#{container_runtime} push #{dest}"
+end
+
+desc 'Combine the per-architecture images into a multi-arch manifest list'
+task :manifest, [:repo] do |t, args|
+  repo = args[:repo]
+  raise(StandardError, "Repository is not specified. Example: \"rake manifest['docker.io']\"") if repo.nil?
+
+  # publish_arch pushes <tag>-<arch>, so without a real tag there's nothing to
+  # assemble and we'd chase :latest-amd64, which is never pushed.
+  raise(StandardError, 'No release tag found - manifest needs a tagged build') if tag == 'latest'
+
+  arches = %w[amd64 arm64]
+
+  src = "#{repo}/#{image_name}:#{tag}"
+
+  %W[#{tag} latest].uniq.each do |t_name|
+    list = "#{repo}/#{image_name}:#{t_name}"
+
+    # Local storage only - matters when rebuilding locally, no-op in CI.
+    sh "#{container_runtime} manifest rm #{list} || true"
+    sh "#{container_runtime} manifest create #{list}"
+
+    # docker:// forces a registry lookup - the per-arch images were pushed by
+    # the other runners and aren't in this one's local storage. Both lists are
+    # built from the versioned tags so `latest` can't mix builds.
+    arches.each do |a|
+      sh "#{container_runtime} manifest add #{list} docker://#{src}-#{a}"
+    end
+
+    # Fail loudly if the list didn't end up with both architectures.
+    sh "#{container_runtime} manifest inspect #{list}"
+
+    sh "#{container_runtime} manifest push --all #{list} docker://#{list}"
+  end
+end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -1,8 +1,7 @@
 def podman_runtime?
-  @podman_runtime ||= begin
-    exists = `command -v podman >/dev/null 2>&1; echo $?`.chomp
-    exists == '0' ? true : false
-  end
+  return @podman_runtime unless @podman_runtime.nil?
+
+  @podman_runtime = `command -v podman >/dev/null 2>&1; echo $?`.chomp == '0'
 end
 
 def docker_build_cmd
@@ -14,12 +13,24 @@ end
 
 def buildah_build_cmd
   args = ['bud', '--layers']
-  args.concat ['-t', "#{image_name}:#{tag}", '-f', 'Dockerfile']
+  args.concat ['-t', "#{image_name}:#{tag}", '-f', 'Dockerfile', '.']
 
   "buildah #{args.join(' ')}"
 end
 
+def podman_build_cmd
+  args = ['build']
+  args.concat ['-t', "#{image_name}:#{tag}", '-f', 'Dockerfile', '.']
+
+  "podman #{args.join(' ')}"
+end
+
 def tag
+  # In a tag-triggered Actions run the ref is authoritative. A shallow checkout
+  # has no local tag refs, so asking git would fall back to 'latest' and quietly
+  # publish over it.
+  return ENV['GITHUB_REF_NAME'] if ENV['GITHUB_REF_TYPE'] == 'tag' && !ENV['GITHUB_REF_NAME'].to_s.empty?
+
   git_tag = `git tag --points-at HEAD`.chomp
   git_tag.empty? ? 'latest' : git_tag
 end
@@ -43,9 +54,18 @@ def image_name
   'openondemand/open-ondemand-demo'
 end
 
+def buildah?
+  return @buildah unless @buildah.nil?
+
+  @buildah = `command -v buildah >/dev/null 2>&1; echo $?`.chomp == '0'
+end
+
 def build_cmd
+  # Stay on whichever runtime container_runtime picked, or the built image
+  # lands in one store and the later tag/push looks in the other. buildah
+  # isn't always installed alongside podman, so fall back to `podman build`.
   if podman_runtime?
-    buildah_build_cmd
+    buildah? ? buildah_build_cmd : podman_build_cmd
   else
     docker_build_cmd
   end


### PR DESCRIPTION
Some setup the tutorial assumes isn't in the image, and a few things have drifted since these were written.

## Container

- **Enable the Develop menu** — set OOD_DEV_APPS_ROOT, which defaults to /dev/null in 4.2 and leaves the app development sections unreachable.
- **Enable dynamic form fields** — set bc_dynamic_js, off by default, so the data-min-*/data-max-* attributes actually do something.the app 500s on first use.
- **Pin the Jupyter stack** — Rocky 9 ships Python 3.9 and current releases need 3.10+, so unpinned rebuilds produce a broken image.
- **Update python3 before installing python3-devel** — --no-cache builds currently fail on that layer.

## Publishing

Build each arch on a native runner and merge them into a manifest list. Only the amd64 build was being pushed, so Docker Hub is amd64-only despite the README — CI already builds arm64 for tests, this wires it into publish too.

## Tutorial

Reword the walkthrough for the single container. Parts still describe the older multi-container demo — a Slurm cluster, a separate frontend host to ssh from.

Also:
- use release_4.2 for the dashboard checkout, not release_3.0
- point MOTD_PATH at /etc/motd.md; /etc/motd is empty here
- use context.cluster in the Kubernetes example — session.cluster returns an object and raises under Ruby 3.2+
- correct after.sh, which runs at launch rather than session end; clean.sh is the cleanup hook
- note that connection.yml is generated rather than authored, and that find_port takes an optional port range
- add a note that sandbox app edits need a web server restart

## Testing

Container changes verified in a from-scratch build — Develop menu, dynamic fields, Job Composer, JupyterLab, and the full app development walkthrough.

The publish workflow only runs on a tag push, so it's untested. Worth watching the first release and confirming with docker manifest inspect. Note the per-arch scratch tags will accumulate on Docker Hub.