### PR TITLE
Install build dependencies missing from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN dnf -y update && \
     dnf install -y epel-release && \
     dnf -y update python3 python3-libs && \
     dnf install -y procps libffi-devel python3-devel gcc && \
+    # Headers for the native gems the tutorial's dashboard build compiles
+    # (nokogiri wants zlib and libxml2/libxslt).
+    dnf install -y zlib-devel libxml2-devel libxslt-devel && \
     dnf install -y ondemand ondemand-dex && \
     dnf install -y xz libyaml-devel turbovnc python3-websockify && \
     dnf groupinstall -y "xfce" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN dnf install -y https://yum.osc.edu/ondemand/4.2/ondemand-release-web-4.2-1.e
     dnf install -y https://yum.osc.edu/ondemand/4.2/ondemand-release-compute-4.2-1.el9.noarch.rpm && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
+# python3-devel resolves against a newer python3 than the first update leaves
+# in place, so python3 is brought up to match before installing it.
 RUN dnf -y update && \
     dnf install -y dnf-utils && \
     dnf config-manager --set-enabled crb && \
     dnf -y module enable nodejs:22 ruby:3.3 && \
     dnf install -y epel-release && \
+    dnf -y update python3 python3-libs && \
     dnf install -y procps libffi-devel python3-devel gcc && \
     dnf install -y ondemand ondemand-dex && \
     dnf install -y xz libyaml-devel turbovnc python3-websockify && \


### PR DESCRIPTION
Two Dockerfile fixes, both only visible to people who rebuild the image or follow the tutorial's build-from-source sections.

`docker build --no-cache` currently fails because `python3-devel` resolves against a newer `python3` than the earlier update leaves in place. Updating `python3` and `python3-libs` first fixes it.

The tutorial's dashboard build compiles nokogiri's native extension, and the image is missing the zlib and libxml2 headers, so it fails at the zlib check and then at `libxml/parser.h`. This came up live during today's workshop.

Testing: full image build on arm64, then confirmed the three packages are present and that nokogiri compiles from source with `--use-system-libraries`, which is the form the dashboard's bundle uses. The no-cache fix was verified on both architectures in CI on a fork earlier.